### PR TITLE
Make shortcut label do less

### DIFF
--- a/src/ShortcutLabel.vala
+++ b/src/ShortcutLabel.vala
@@ -17,38 +17,25 @@
 
 
 public class ShortcutLabel : Gtk.Grid {
-    public Gtk.Label name_label { get; private set; }
-    public ShortcutEntry entry { get; construct; }
+    public string[] accels { get; construct; }
 
-    public ShortcutLabel (ShortcutEntry entry) {
-        Object (entry: entry);
+    public ShortcutLabel (string[] accels ) {
+        Object (accels: accels);
     }
 
     construct {
-        orientation = Gtk.Orientation.HORIZONTAL;
-        column_spacing = 12;
+        column_spacing = 6;
 
-        name_label = new Gtk.Label (entry.name);
-        name_label.halign = Gtk.Align.END;
-        name_label.xalign = 1;
-        add (name_label);
-
-        var accel_grid = new Gtk.Grid ();
-        accel_grid.orientation = Gtk.Orientation.HORIZONTAL;
-        accel_grid.column_spacing = 6;
-
-        if (entry.accels[0] != "") {
-            foreach (string accel in entry.accels) {
+        if (accels[0] != "") {
+            foreach (unowned string accel in accels) {
                 var label = new Gtk.Label (accel);
                 label.get_style_context ().add_class ("keycap");
-                accel_grid.add (label);
+                add (label);
             }
         } else {
             var label = new Gtk.Label (_("Disabled"));
             label.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
-            accel_grid.add (label);
+            add (label);
         }
-
-        add (accel_grid);
     }
 }

--- a/src/Views/ShortcutsView.vala
+++ b/src/Views/ShortcutsView.vala
@@ -103,9 +103,20 @@ public class ShortcutOverlay.ShortcutsView : Gtk.Grid {
 
     private void add_shortcut_entries (Gee.ArrayList<ShortcutEntry> entries, Gtk.Grid column) {
         foreach (var entry in entries) {
-            var label = new ShortcutLabel (entry);
-            column.add (label);
-            size_group.add_widget (label.name_label);
+            var name_label = new Gtk.Label (entry.name);
+            name_label.halign = Gtk.Align.END;
+            name_label.xalign = 1;
+
+            var shortcut_label = new ShortcutLabel (entry.accels);
+
+            var grid = new Gtk.Grid ();
+            grid.orientation = Gtk.Orientation.HORIZONTAL;
+            grid.column_spacing = 12;
+            grid.add (name_label);
+            grid.add (shortcut_label);
+
+            column.add (grid);
+            size_group.add_widget (name_label);
         }
     }
 }

--- a/src/Views/ShortcutsView.vala
+++ b/src/Views/ShortcutsView.vala
@@ -27,6 +27,7 @@ public class ShortcutOverlay.ShortcutsView : Gtk.Grid {
     private const string SCHEMA_MUTTER = "org.gnome.mutter.keybindings";
 
     private static Gtk.SizeGroup size_group;
+    private int column_y_value = 0;
 
     static construct {
         system_entries = new Gee.ArrayList<ShortcutEntry> ();
@@ -63,32 +64,34 @@ public class ShortcutOverlay.ShortcutsView : Gtk.Grid {
 
     construct {
         var column_start = new Gtk.Grid ();
+        column_start.column_spacing = 12;
         column_start.hexpand = true;
         column_start.orientation = Gtk.Orientation.VERTICAL;
         column_start.row_spacing = 12;
 
-        size_group = new Gtk.SizeGroup (Gtk.SizeGroupMode.HORIZONTAL);
-
-        var window_header = new Granite.HeaderLabel (_("Windows"));
-        column_start.add (window_header);
+        column_start.add (new Granite.HeaderLabel (_("Windows")));
+        column_y_value ++;
         add_shortcut_entries (window_entries, column_start);
 
-        var workspace_header = new Granite.HeaderLabel (_("Workspaces"));
-        column_start.add (workspace_header);
+        column_start.add (new Granite.HeaderLabel (_("Workspaces")));
+        column_y_value ++;
         add_shortcut_entries (workspace_entries, column_start);
 
+        column_y_value = 0;
+
         var column_end = new Gtk.Grid ();
+        column_end.column_spacing = 12;
         column_end.halign = Gtk.Align.START;
         column_end.hexpand = true;
         column_end.orientation = Gtk.Orientation.VERTICAL;
         column_end.row_spacing = 12;
 
-        var system_header = new Granite.HeaderLabel (_("System"));
-        column_end.add (system_header);
+        column_end.add (new Granite.HeaderLabel (_("System")));
+        column_y_value ++;
         add_shortcut_entries (system_entries, column_end);
 
-        var screenshot_header = new Granite.HeaderLabel (_("Screenshots"));
-        column_end.add (screenshot_header);
+        column_end.add (new Granite.HeaderLabel (_("Screenshots")));
+        column_y_value ++;
         add_shortcut_entries (screenshot_entries, column_end);
 
         var column_size_group = new Gtk.SizeGroup (Gtk.SizeGroupMode.HORIZONTAL);
@@ -109,14 +112,10 @@ public class ShortcutOverlay.ShortcutsView : Gtk.Grid {
 
             var shortcut_label = new ShortcutLabel (entry.accels);
 
-            var grid = new Gtk.Grid ();
-            grid.orientation = Gtk.Orientation.HORIZONTAL;
-            grid.column_spacing = 12;
-            grid.add (name_label);
-            grid.add (shortcut_label);
+            column.attach (name_label, 0, column_y_value);
+            column.attach (shortcut_label, 1, column_y_value);
 
-            column.add (grid);
-            size_group.add_widget (name_label);
+            column_y_value++;
         }
     }
 }

--- a/src/Views/ShortcutsView.vala
+++ b/src/Views/ShortcutsView.vala
@@ -25,8 +25,6 @@ public class ShortcutOverlay.ShortcutsView : Gtk.Grid {
     private const string SCHEMA_GALA = "org.pantheon.desktop.gala.keybindings";
     private const string SCHEMA_MEDIA = "org.gnome.settings-daemon.plugins.media-keys";
     private const string SCHEMA_MUTTER = "org.gnome.mutter.keybindings";
-
-    private static Gtk.SizeGroup size_group;
     private int column_y_value = 0;
 
     static construct {


### PR DESCRIPTION
Needed to solve #46 since it doesn't fit into how ShortcutEntry works. This also uses fewer grids and makes it so we don't need size groups