### PR TITLE
l10n: Correctly setup the locales

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -20,12 +20,22 @@ add_global_arguments([
     language:'c'
 )
 
+config_data = configuration_data()
+config_data.set_quoted('LOCALEDIR', join_paths(get_option('prefix'), get_option('localedir')))
+config_data.set_quoted('GETTEXT_PACKAGE', meson.project_name())
+config_file = configure_file(
+    input: 'src/Config.vala.in',
+    output: '@BASENAME@',
+    configuration: config_data
+)
+
 executable(
     meson.project_name(),
     'src/Application.vala',
     'src/MainWindow.vala',
     'src/ShortcutLabel.vala',
     'src/Views/ShortcutsView.vala',
+    config_file,
     asresources,
     dependencies: [
         dependency('glib-2.0'),

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -72,6 +72,11 @@ public class ShortcutOverlay.Application : Gtk.Application {
 }
 
 public static int main (string[] args) {
+    GLib.Intl.setlocale (LocaleCategory.ALL, "");
+    GLib.Intl.bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
+    GLib.Intl.bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
+    GLib.Intl.textdomain (GETTEXT_PACKAGE);
+
     var application = new ShortcutOverlay.Application ();
     return application.run (args);
 }

--- a/src/Config.vala.in
+++ b/src/Config.vala.in
@@ -1,0 +1,2 @@
+public const string GETTEXT_PACKAGE = @GETTEXT_PACKAGE@;
+public const string LOCALEDIR = @LOCALEDIR@;


### PR DESCRIPTION
Provides the directory where the locales are actually installed.

We are [packaging this](https://github.com/NixOS/nixpkgs/pull/130380#issuecomment-895720580) in NixOS, and due to NixOS 's special `localedir`, we cannot apply the translations without this patch.

Thanks in advance for reviewing this :-)