### PR TITLE
ShortcutLabel: Fix Gee warnings

### DIFF
--- a/src/ShortcutLabel.vala
+++ b/src/ShortcutLabel.vala
@@ -23,9 +23,7 @@ public class ShortcutLabel : Gtk.Grid {
     private static Settings get_settings_for_schema (string schema_id) {
         if (settings_list == null) {
             settings_list = new Gee.ArrayList<Settings> ();
-        }
-
-        if (settings_list.size > 0) {
+        } else if (settings_list.size > 0) {
             foreach (var settings in settings_list) {
                 if (settings.schema_id == schema_id) {
                     return settings;


### PR DESCRIPTION
Fixes the following warnings on launch:

```
** (io.elementary.shortcut-overlay:10966): CRITICAL **: 06:39:24.936: gee_abstract_collection_get_size: assertion 'self != NULL' failed

** (io.elementary.shortcut-overlay:10966): CRITICAL **: 06:39:24.936: gee_abstract_collection_add: assertion 'self != NULL' failed
```
