### PR TITLE
Port to GTK4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,14 +8,14 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: elementary/docker:odin-unstable
+      image: elementary/docker:next-unstable
 
     steps:
     - uses: actions/checkout@v2
     - name: Install Dependencies
       run: |
         apt update
-        apt install -y libgee-0.8-dev libgranite-dev libgtk-3-dev libhandy-1-dev meson valac
+        apt install -y libgee-0.8-dev libgranite-7-dev libgtk-4-dev meson valac
     - name: Build
       env:
         DESTDIR: out

--- a/data/application.css
+++ b/data/application.css
@@ -1,7 +1,0 @@
-decoration {
-    box-shadow:
-        0 0 0 1px @borders,
-        0 3px 8px 2px alpha(black, 0.1),
-        0 5px 5px -3px alpha(black, 0.4),
-        0 8px 5px 1px alpha(black, 0.1);
-}

--- a/data/io.elementary.shortcut-overlay.gresource.xml
+++ b/data/io.elementary.shortcut-overlay.gresource.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<gresources>
-  <gresource prefix="/io/elementary/shortcut-overlay">
-    <file alias="application.css" compressed="true">application.css</file>
-  </gresource>
-</gresources>

--- a/meson.build
+++ b/meson.build
@@ -7,12 +7,6 @@ project(
 gnome = import('gnome')
 i18n = import('i18n')
 
-asresources = gnome.compile_resources(
-    'as-resources', 'data/' + meson.project_name() + '.gresource.xml',
-    source_dir: 'data',
-    c_name: 'as'
-)
-
 add_global_arguments([
         '-DGETTEXT_PACKAGE="@0@"'.format(meson.project_name()),
         '-DHANDY_USE_UNSTABLE_API'
@@ -36,14 +30,12 @@ executable(
     'src/ShortcutLabel.vala',
     'src/Views/ShortcutsView.vala',
     config_file,
-    asresources,
     dependencies: [
         dependency('glib-2.0'),
         dependency('gobject-2.0'),
-        dependency('granite', version: '>= 5.4.0'),
-        dependency('gtk+-3.0'),
+        dependency('granite-7', version: '>= 7.0.0'),
+        dependency('gtk4'),
         dependency('gee-0.8'),
-        dependency('libhandy-1', version: '>=0.80.0'),
         meson.get_compiler('vala').find_library('posix'),
     ],
     install : true

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -33,7 +33,7 @@ public class ShortcutOverlay.Application : Gtk.Application {
         bool is_terminal = Posix.isatty (Posix.STDIN_FILENO);
 
         var main_window = new MainWindow (this);
-        main_window.show_all ();
+        main_window.present ();
 
         var quit_action = new SimpleAction ("quit", null);
 
@@ -41,10 +41,10 @@ public class ShortcutOverlay.Application : Gtk.Application {
         set_accels_for_action ("app.quit", {"Escape"});
 
         if (is_terminal == false) {
-            main_window.focus_out_event.connect ((event) => {
-                quit_action.activate (null);
-                return Gdk.EVENT_STOP;
-            });
+            // main_window.focus_out_event.connect ((event) => {
+            //     quit_action.activate (null);
+            //     return Gdk.EVENT_STOP;
+            // });
         }
 
         quit_action.activate.connect (() => {

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -30,8 +30,6 @@ public class ShortcutOverlay.Application : Gtk.Application {
             return;
         }
 
-        bool is_terminal = Posix.isatty (Posix.STDIN_FILENO);
-
         var main_window = new MainWindow (this);
         main_window.present ();
 
@@ -40,12 +38,19 @@ public class ShortcutOverlay.Application : Gtk.Application {
         add_action (quit_action);
         set_accels_for_action ("app.quit", {"Escape"});
 
-        if (is_terminal == false) {
-            // main_window.focus_out_event.connect ((event) => {
-            //     quit_action.activate (null);
-            //     return Gdk.EVENT_STOP;
-            // });
+        if (Posix.isatty (Posix.STDIN_FILENO) == false) {
+            var focus_controller = new Gtk.EventControllerLegacy ();
+            focus_controller.event.connect ((event) => {
+                if (event.get_event_type () == Gdk.EventType.FOCUS_CHANGE && !((Gdk.FocusEvent) event).get_in ()) {
+                    quit_action.activate (null);
+                }
+
+                return Gdk.EVENT_PROPAGATE;
+            });
+
+            ((Gtk.Widget) main_window).add_controller (focus_controller);
         }
+
 
         quit_action.activate.connect (() => {
             if (main_window != null) {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -45,7 +45,7 @@ public class ShortcutOverlay.MainWindow : Gtk.Window {
         var title_label = new Gtk.Label (_("Shorcuts")) {
             hexpand = true
         };
-        title_label.add_css_class ("title");
+        title_label.add_css_class (Granite.STYLE_CLASS_TITLE_LABEL);
 
         var end_controls = new Gtk.WindowControls (Gtk.PackType.END);
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -29,7 +29,6 @@ public class ShortcutOverlay.MainWindow : Gtk.Window {
             icon_name = "preferences-system-symbolic",
             tooltip_text = _("Keyboard Settings…")
         };
-        settings_button.add_css_class ("titlebutton");
 
         var shortcuts_view = new ShortcutsView () {
             margin_start = 36,

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-public class ShortcutOverlay.MainWindow : Hdy.Window {
+public class ShortcutOverlay.MainWindow : Gtk.Window {
     public MainWindow (Gtk.Application application) {
         Object (
             application: application,
@@ -25,27 +25,11 @@ public class ShortcutOverlay.MainWindow : Hdy.Window {
     }
 
     construct {
-        var css_provider = new Gtk.CssProvider ();
-        css_provider.load_from_resource ("io/elementary/shortcut-overlay/application.css");
-        Gtk.StyleContext.add_provider_for_screen (get_screen (), css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
-
-        var settings_button = new Gtk.Button.from_icon_name ("preferences-system-symbolic", Gtk.IconSize.MENU) {
-            tooltip_text = _("Keyboard Settings…"),
-            valign = Gtk.Align.CENTER
+        var settings_button = new Gtk.Button () {
+            icon_name = "preferences-system-symbolic",
+            tooltip_text = _("Keyboard Settings…")
         };
-        settings_button.get_style_context ().add_class ("titlebutton");
-
-        var headerbar = new Gtk.HeaderBar () {
-            title = _("Shortcuts"),
-            has_subtitle = false,
-            show_close_button = true
-        };
-        headerbar.pack_end (settings_button);
-
-        unowned Gtk.StyleContext headerbar_context = headerbar.get_style_context ();
-        headerbar_context.add_class ("default-decoration");
-        headerbar_context.add_class (Gtk.STYLE_CLASS_FLAT);
-        headerbar_context.add_class (Gtk.STYLE_CLASS_TITLEBAR);
+        settings_button.add_css_class ("titlebutton");
 
         var shortcuts_view = new ShortcutsView () {
             margin_start = 36,
@@ -54,14 +38,30 @@ public class ShortcutOverlay.MainWindow : Hdy.Window {
             margin_bottom = 36
         };
 
-        var grid = new Gtk.Grid () {
-            orientation = Gtk.Orientation.VERTICAL
-        };
-        grid.add (headerbar);
-        grid.add (shortcuts_view);
+        child = shortcuts_view;
 
-        skip_taskbar_hint = true;
-        add (grid);
+        var start_controls = new Gtk.WindowControls (Gtk.PackType.START);
+
+        var title_label = new Gtk.Label (_("Shorcuts")) {
+            hexpand = true
+        };
+        title_label.add_css_class ("title");
+
+        var end_controls = new Gtk.WindowControls (Gtk.PackType.END);
+
+        var titlebar = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
+        titlebar.append (start_controls);
+        titlebar.append (title_label);
+        titlebar.append (settings_button);
+
+        if (!end_controls.empty) {
+            titlebar.append (end_controls);
+        }
+
+        titlebar.add_css_class (Granite.STYLE_CLASS_FLAT);
+        titlebar.add_css_class (Granite.STYLE_CLASS_DEFAULT_DECORATION);
+
+        set_titlebar (titlebar);
 
         settings_button.clicked.connect (() => {
             try {

--- a/src/ShortcutLabel.vala
+++ b/src/ShortcutLabel.vala
@@ -16,7 +16,7 @@
  */
 
 
-public class ShortcutLabel : Gtk.Grid {
+public class ShortcutLabel : Gtk.Box {
     public string[] accels { get; construct; }
 
     private static Gee.ArrayList<Settings> settings_list;
@@ -59,7 +59,7 @@ public class ShortcutLabel : Gtk.Grid {
     }
 
     construct {
-        column_spacing = 6;
+        spacing = 6;
 
         if (accels[0] != "") {
             foreach (unowned string accel in accels) {
@@ -68,12 +68,12 @@ public class ShortcutLabel : Gtk.Grid {
                 }
                 var label = new Gtk.Label (accel);
                 label.get_style_context ().add_class ("keycap");
-                add (label);
+                append (label);
             }
         } else {
             var label = new Gtk.Label (_("Disabled"));
-            label.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
-            add (label);
+            label.add_css_class (Granite.STYLE_CLASS_DIM_LABEL);
+            append (label);
         }
     }
 }

--- a/src/Views/ShortcutsView.vala
+++ b/src/Views/ShortcutsView.vala
@@ -15,19 +15,25 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-public class ShortcutOverlay.ShortcutsView : Gtk.Grid {
+public class ShortcutOverlay.ShortcutsView : Gtk.Box {
     private const string SCHEMA_WM = "org.gnome.desktop.wm.keybindings";
     private const string SCHEMA_GALA = "org.pantheon.desktop.gala.keybindings";
     private const string SCHEMA_MEDIA = "org.gnome.settings-daemon.plugins.media-keys";
     private const string SCHEMA_MUTTER = "org.gnome.mutter.keybindings";
 
     construct {
-        var column_start = new Gtk.Grid ();
-        column_start.column_spacing = 12;
-        column_start.hexpand = true;
-        column_start.row_spacing = 12;
+        var column_start = new Gtk.Grid () {
+            column_spacing = 12,
+            hexpand = true,
+            row_spacing = 12
+        };
 
-        column_start.attach (new Granite.HeaderLabel (_("Windows")), 0, 0, 2);
+        var windows_header = new Gtk.Label (_("Windows")) {
+            xalign = 0
+        };
+        windows_header.add_css_class (Granite.STYLE_CLASS_H4_LABEL);
+
+        column_start.attach (windows_header, 0, 0, 2);
         column_start.attach (new NameLabel (_("Close window:")), 0, 1);
         column_start.attach (new ShortcutLabel.from_gsettings (SCHEMA_WM, "close"), 1, 1);
         column_start.attach (new NameLabel (_("Cycle windows:")), 0, 2);
@@ -45,7 +51,12 @@ public class ShortcutOverlay.ShortcutsView : Gtk.Grid {
         column_start.attach (new NameLabel (_("Picture in Picture Mode:")), 0, 8);
         column_start.attach (new ShortcutLabel.from_gsettings (SCHEMA_GALA, "pip"), 1, 8);
 
-        column_start.attach (new Granite.HeaderLabel (_("Workspaces")), 0, 9, 2);
+        var workspaces_header = new Gtk.Label (_("Workspaces")) {
+            xalign = 0
+        };
+        workspaces_header.add_css_class (Granite.STYLE_CLASS_H4_LABEL);
+
+        column_start.attach (workspaces_header, 0, 9, 2);
         column_start.attach (new NameLabel (_("Multitasking View:")), 0, 10);
         column_start.attach (new ShortcutLabel.from_gsettings (SCHEMA_WM, "show-desktop"), 1, 10);
         column_start.attach (new NameLabel (_("Switch left:")), 0, 11);
@@ -104,7 +115,12 @@ public class ShortcutOverlay.ShortcutsView : Gtk.Grid {
         column_end.hexpand = true;
         column_end.row_spacing = 12;
 
-        column_end.attach (new Granite.HeaderLabel (_("System")), 0, 0, 2);
+        var system_header = new Gtk.Label (_("System")) {
+            xalign = 0
+        };
+        system_header.add_css_class (Granite.STYLE_CLASS_H4_LABEL);
+
+        column_end.attach (system_header, 0, 0, 2);
         column_end.attach (new NameLabel (_("Applications Menu:")), 0, 1);
         column_end.attach (new ShortcutLabel.from_gsettings (SCHEMA_WM, "panel-main-menu"), 1, 1);
         column_end.attach (new NameLabel (_("Cycle display mode:")), 0, 2);
@@ -120,7 +136,12 @@ public class ShortcutOverlay.ShortcutsView : Gtk.Grid {
         column_end.attach (new NameLabel (_("Switch keyboard layout:")), 0, 7);
         column_end.attach (new ShortcutLabel (xkb_input_accels), 1, 7);
 
-        column_end.attach (new Granite.HeaderLabel (_("Screenshots")), 0, 8, 2);
+        var screenshots_header = new Gtk.Label (_("Screenshots")) {
+            xalign = 0
+        };
+        screenshots_header.add_css_class (Granite.STYLE_CLASS_H4_LABEL);
+
+        column_end.attach (screenshots_header , 0, 8, 2);
         column_end.attach (new NameLabel (_("Grab the whole screen:")), 0, 9);
         column_end.attach (new ShortcutLabel.from_gsettings (SCHEMA_MEDIA, "screenshot"), 1, 9);
         column_end.attach (new NameLabel (_("Copy the whole screen to clipboard:")), 0, 10);
@@ -138,22 +159,24 @@ public class ShortcutOverlay.ShortcutsView : Gtk.Grid {
         column_size_group.add_widget (column_start);
         column_size_group.add_widget (column_end);
 
-        column_spacing = 48;
-        add (column_start);
-        add (new Gtk.Separator (Gtk.Orientation.VERTICAL));
-        add (column_end);
+        spacing = 48;
+        append (column_start);
+        append (new Gtk.Separator (Gtk.Orientation.VERTICAL));
+        append (column_end);
     }
 
-    private class NameLabel : Gtk.Label {
+    private class NameLabel : Gtk.Box {
+        public string label { get; construct; }
+
         public NameLabel (string label) {
-            Object (
-                label: label
-            );
+            Object (label: label);
         }
 
         construct {
+            var label = new Gtk.Label (label);
+
             halign = Gtk.Align.END;
-            xalign = 1;
+            append (label);
         }
     }
 }


### PR DESCRIPTION
Fixes #109 

Keep the window non-draggable by making a custom titlebar with a box and `Gtk.WindowControls`

Todo:
- [x] Figure out how to get focus out

Blocked by:
- [x] https://github.com/elementary/docker/pull/21
- [x] https://github.com/elementary/granite/pull/562