### PR TITLE
Meson: remove positional arguments from i18n.merge_file

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -8,7 +8,6 @@ i18n.merge_file (
 )
 
 i18n.merge_file (
-    'desktop',
     input: 'shortcut-overlay.desktop.in',
     output: meson.project_name() + '.desktop',
     po_dir: join_paths(meson.source_root (), 'po', 'extra'),


### PR DESCRIPTION
`i18n.merge_file` has been ignoring positional arguments for a time and explicitly rejects with error since meson 0.60.0.