### PR TITLE
Added "Keyboard Settings…" button | Fixed typo in titlebar

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -25,11 +25,6 @@ public class ShortcutOverlay.MainWindow : Gtk.Window {
     }
 
     construct {
-        var settings_button = new Gtk.Button () {
-            icon_name = "preferences-system-symbolic",
-            tooltip_text = _("Keyboard Settings…")
-        };
-
         var shortcuts_view = new ShortcutsView () {
             margin_start = 36,
             margin_end = 36,
@@ -51,7 +46,6 @@ public class ShortcutOverlay.MainWindow : Gtk.Window {
         var titlebar = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
         titlebar.append (start_controls);
         titlebar.append (title_label);
-        titlebar.append (settings_button);
 
         if (!end_controls.empty) {
             titlebar.append (end_controls);
@@ -61,13 +55,5 @@ public class ShortcutOverlay.MainWindow : Gtk.Window {
         titlebar.add_css_class (Granite.STYLE_CLASS_DEFAULT_DECORATION);
 
         set_titlebar (titlebar);
-
-        settings_button.clicked.connect (() => {
-            try {
-                AppInfo.launch_default_for_uri ("settings://input/keyboard/shortcuts", null);
-            } catch (Error e) {
-                warning (e.message);
-            }
-        });
     }
 }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -36,7 +36,7 @@ public class ShortcutOverlay.MainWindow : Gtk.Window {
 
         var start_controls = new Gtk.WindowControls (Gtk.PackType.START);
 
-        var title_label = new Gtk.Label (_("Shorcuts")) {
+        var title_label = new Gtk.Label (_("Shortcuts")) {
             hexpand = true
         };
         title_label.add_css_class (Granite.STYLE_CLASS_TITLE_LABEL);

--- a/src/Views/ShortcutsView.vala
+++ b/src/Views/ShortcutsView.vala
@@ -22,6 +22,16 @@ public class ShortcutOverlay.ShortcutsView : Gtk.Box {
     private const string SCHEMA_MUTTER = "org.gnome.mutter.keybindings";
 
     construct {
+        var settings_button = new Gtk.Button.with_label(_("Keyboard Settings…"));
+
+        settings_button.clicked.connect(() => {
+            try {
+                AppInfo.launch_default_for_uri ("settings://input/keyboard/shortcuts", null);
+            } catch (Error e) {
+                warning (e.message);
+            }
+        });
+
         var column_start = new Gtk.Grid () {
             column_spacing = 12,
             hexpand = true,
@@ -154,6 +164,7 @@ public class ShortcutOverlay.ShortcutsView : Gtk.Box {
         column_end.attach (new ShortcutLabel.from_gsettings (SCHEMA_MEDIA, "area-screenshot"), 1, 13);
         column_end.attach (new NameLabel (_("Copy an area to clipboard:")), 0, 14);
         column_end.attach (new ShortcutLabel.from_gsettings (SCHEMA_MEDIA, "area-screenshot-clip"), 1, 14);
+        column_end.attach (settings_button, 1, 15);
 
         var column_size_group = new Gtk.SizeGroup (Gtk.SizeGroupMode.HORIZONTAL);
         column_size_group.add_widget (column_start);


### PR DESCRIPTION
Fixes #108 and a typo in the title "Shortcuts".