### PR TITLE
Release 8.0.1

### DIFF
--- a/data/shortcut-overlay.metainfo.xml.in
+++ b/data/shortcut-overlay.metainfo.xml.in
@@ -38,6 +38,14 @@
   <update_contact>contact_at_elementary.io</update_contact>
 
   <releases>
+    <release version="8.0.1" date="2024-08-18">
+      <description>
+        <ul>
+          <li>Updated translations</li>
+        </ul>
+      </description>
+    </release>
+
     <release version="8.0.0" date="2024-06-06">
       <description>
         <ul>
@@ -77,16 +85,7 @@
       </description>
     </release>
 
-    <release version="1.2.0" date="2021-07-14" urgency="medium">
-      <description>
-        <ul>
-          <li>Add screenshot shortcuts</li>
-          <li>Fix issues with multiple windows</li>
-          <li>Updated translations</li>
-        </ul>
-      </description>
-    </release>
-
+    <release version="1.2.0" date="2021-07-14" urgency="medium" />
     <release version="1.1.2" date="2020-05-28" urgency="medium" />
     <release version="1.1.1" date="2020-04-02" urgency="medium" />
     <release version="1.1.0" date="2019-11-15" urgency="medium" />

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'io.elementary.shortcut-overlay',
     'vala', 'c',
-    version: '8.0.0'
+    version: '8.0.1'
 )
 
 gnome = import('gnome')


### PR DESCRIPTION
For new gala schema

Also updated runtime dep: https://github.com/elementary/shortcut-overlay/blob/deb-packaging/debian/control