### PR TITLE
ShortcutLabel: move human label here

### DIFF
--- a/src/ShortcutLabel.vala
+++ b/src/ShortcutLabel.vala
@@ -23,7 +23,7 @@ public class ShortcutLabel : Gtk.Box {
     private static Gtk.SizeGroup sizegroup;
     private static Gtk.SizeGroup shortcut_sizegroup;
 
-    public ShortcutLabel (string label, string[] accels ) {
+    public ShortcutLabel (string label, string[] accels) {
         Object (
             accels: accels,
             label: label

--- a/src/Views/ShortcutsView.vala
+++ b/src/Views/ShortcutsView.vala
@@ -31,38 +31,24 @@ public class ShortcutOverlay.ShortcutsView : Gtk.Box {
         var windows_header = new Granite.HeaderLabel (_("Windows"));
 
         column_start.attach (windows_header, 0, 0, 2);
-        column_start.attach (new NameLabel (_("Close window:")), 0, 1);
-        column_start.attach (new ShortcutLabel.from_gsettings (SCHEMA_WM, "close"), 1, 1);
-        column_start.attach (new NameLabel (_("Cycle windows:")), 0, 2);
-        column_start.attach (new ShortcutLabel.from_gsettings (SCHEMA_WM, "switch-windows"), 1, 2);
-        column_start.attach (new NameLabel (_("Toggle maximized:")), 0, 3);
-        column_start.attach (new ShortcutLabel.from_gsettings (SCHEMA_WM, "toggle-maximized"), 1, 3);
-        column_start.attach (new NameLabel (_("Tile left:")), 0, 4);
-        column_start.attach (new ShortcutLabel.from_gsettings (SCHEMA_MUTTER, "toggle-tiled-left"), 1, 4);
-        column_start.attach (new NameLabel (_("Tile right:")), 0, 5);
-        column_start.attach (new ShortcutLabel.from_gsettings (SCHEMA_MUTTER, "toggle-tiled-right"), 1, 5);
-        column_start.attach (new NameLabel (_("Move to left workspace:")), 0, 6);
-        column_start.attach (new ShortcutLabel.from_gsettings (SCHEMA_WM, "move-to-workspace-left"), 1, 6);
-        column_start.attach (new NameLabel (_("Move to right workspace:")), 0, 7);
-        column_start.attach (new ShortcutLabel.from_gsettings (SCHEMA_WM, "move-to-workspace-right"), 1, 7);
-        column_start.attach (new NameLabel (_("Picture in Picture Mode:")), 0, 8);
-        column_start.attach (new ShortcutLabel.from_gsettings (SCHEMA_GALA, "pip"), 1, 8);
+        column_start.attach (new ShortcutLabel.from_gsettings (_("Close window:"), SCHEMA_WM, "close"), 0, 1);
+        column_start.attach (new ShortcutLabel.from_gsettings (_("Cycle windows:"), SCHEMA_WM, "switch-windows"), 0, 2);
+        column_start.attach (new ShortcutLabel.from_gsettings (_("Toggle maximized:"), SCHEMA_WM, "toggle-maximized"), 0, 3);
+        column_start.attach (new ShortcutLabel.from_gsettings (_("Tile left:"), SCHEMA_MUTTER, "toggle-tiled-left"), 0, 4);
+        column_start.attach (new ShortcutLabel.from_gsettings (_("Tile right:"), SCHEMA_MUTTER, "toggle-tiled-right"), 0, 5);
+        column_start.attach (new ShortcutLabel.from_gsettings (_("Move to left workspace:"), SCHEMA_WM, "move-to-workspace-left"), 0, 6);
+        column_start.attach (new ShortcutLabel.from_gsettings (_("Move to right workspace:"), SCHEMA_WM, "move-to-workspace-right"), 0, 7);
+        column_start.attach (new ShortcutLabel.from_gsettings (_("Picture in Picture Mode:"), SCHEMA_GALA, "pip"), 0, 8);
 
         var workspaces_header = new Granite.HeaderLabel (_("Workspaces"));
 
         column_start.attach (workspaces_header, 0, 9, 2);
-        column_start.attach (new NameLabel (_("Multitasking View:")), 0, 10);
-        column_start.attach (new ShortcutLabel.from_gsettings (SCHEMA_GALA, "toggle-multitasking-view"), 1, 10);
-        column_start.attach (new NameLabel (_("Switch left:")), 0, 11);
-        column_start.attach (new ShortcutLabel.from_gsettings (SCHEMA_WM, "switch-to-workspace-left"), 1, 11);
-        column_start.attach (new NameLabel (_("Switch right:")), 0, 12);
-        column_start.attach (new ShortcutLabel.from_gsettings (SCHEMA_WM, "switch-to-workspace-right"), 1, 12);
-        column_start.attach (new NameLabel (_("Switch to first:")), 0, 13);
-        column_start.attach (new ShortcutLabel.from_gsettings (SCHEMA_GALA, "switch-to-workspace-first"), 1, 13);
-        column_start.attach (new NameLabel (_("Switch to new:")), 0, 14);
-        column_start.attach (new ShortcutLabel.from_gsettings (SCHEMA_GALA, "switch-to-workspace-last"), 1, 14);
-        column_start.attach (new NameLabel (_("Cycle workspaces:")), 0, 15);
-        column_start.attach (new ShortcutLabel.from_gsettings (SCHEMA_GALA, "cycle-workspaces-next"), 1, 15);
+        column_start.attach (new ShortcutLabel.from_gsettings (_("Multitasking View:"), SCHEMA_GALA, "toggle-multitasking-view"), 0, 10);
+        column_start.attach (new ShortcutLabel.from_gsettings (_("Switch left:"), SCHEMA_WM, "switch-to-workspace-left"), 0, 11);
+        column_start.attach (new ShortcutLabel.from_gsettings (_("Switch right:"), SCHEMA_WM, "switch-to-workspace-right"), 0, 12);
+        column_start.attach (new ShortcutLabel.from_gsettings (_("Switch to first:"), SCHEMA_GALA, "switch-to-workspace-first"), 0, 13);
+        column_start.attach (new ShortcutLabel.from_gsettings (_("Switch to new:"), SCHEMA_GALA, "switch-to-workspace-last"), 0, 14);
+        column_start.attach (new ShortcutLabel.from_gsettings (_("Cycle workspaces:"), SCHEMA_GALA, "cycle-workspaces-next"), 0, 15);
 
         var input_settings = new GLib.Settings ("org.gnome.desktop.input-sources");
         var xkb_options = input_settings.get_strv ("xkb-options");
@@ -112,63 +98,29 @@ public class ShortcutOverlay.ShortcutsView : Gtk.Box {
         var system_header = new Granite.HeaderLabel (_("System"));
 
         column_end.attach (system_header, 0, 0, 2);
-        column_end.attach (new NameLabel (_("Applications Menu:")), 0, 1);
-        column_end.attach (new ShortcutLabel.from_gsettings (SCHEMA_GALA, "panel-main-menu"), 1, 1);
-        column_end.attach (new NameLabel (_("Cycle display mode:")), 0, 2);
-        column_end.attach (new ShortcutLabel.from_gsettings (SCHEMA_MUTTER, "switch-monitor"), 1, 2);
-        column_end.attach (new NameLabel (_("Zoom in:")), 0, 3);
-        column_end.attach (new ShortcutLabel.from_gsettings (SCHEMA_GALA, "zoom-in"), 1, 3);
-        column_end.attach (new NameLabel (_("Zoom out:")), 0, 4);
-        column_end.attach (new ShortcutLabel.from_gsettings (SCHEMA_GALA, "zoom-out"), 1, 4);
-        column_end.attach (new NameLabel (_("Lock screen:")), 0, 5);
-        column_end.attach (new ShortcutLabel.from_gsettings (SCHEMA_MEDIA, "screensaver"), 1, 5);
-        column_end.attach (new NameLabel (_("Log out:")), 0, 6);
-        column_end.attach (new ShortcutLabel.from_gsettings (SCHEMA_MEDIA, "logout"), 1, 6);
-        column_end.attach (new NameLabel (_("Switch keyboard layout:")), 0, 7);
-        column_end.attach (new ShortcutLabel (xkb_input_accels), 1, 7);
-        column_end.attach (new NameLabel (_("Toggle on-screen keyboard:")), 0, 8);
-        column_end.attach (new ShortcutLabel.from_gsettings (SCHEMA_MEDIA, "on-screen-keyboard"), 1, 8);
-        column_end.attach (new NameLabel (_("Toggle screen reader:")), 0, 9);
-        column_end.attach (new ShortcutLabel.from_gsettings (SCHEMA_MEDIA, "screenreader"), 1, 9);
+        column_end.attach (new ShortcutLabel.from_gsettings (_("Applications Menu:"), SCHEMA_GALA, "panel-main-menu"), 0, 1);
+        column_end.attach (new ShortcutLabel.from_gsettings (_("Cycle display mode:"), SCHEMA_MUTTER, "switch-monitor"), 0, 2);
+        column_end.attach (new ShortcutLabel.from_gsettings (_("Zoom in:"), SCHEMA_GALA, "zoom-in"), 0, 3);
+        column_end.attach (new ShortcutLabel.from_gsettings (_("Zoom out:"), SCHEMA_GALA, "zoom-out"), 0, 4);
+        column_end.attach (new ShortcutLabel.from_gsettings (_("Lock screen:"), SCHEMA_MEDIA, "screensaver"), 0, 5);
+        column_end.attach (new ShortcutLabel.from_gsettings (_("Log out:"), SCHEMA_MEDIA, "logout"), 0, 6);
+        column_end.attach (new ShortcutLabel (_("Switch keyboard layout:"), xkb_input_accels), 0, 7);
+        column_end.attach (new ShortcutLabel.from_gsettings (_("Toggle on-screen keyboard:"), SCHEMA_MEDIA, "on-screen-keyboard"), 0, 8);
+        column_end.attach (new ShortcutLabel.from_gsettings (_("Toggle screen reader:"), SCHEMA_MEDIA, "screenreader"), 0, 9);
 
         var screenshots_header = new Granite.HeaderLabel (_("Screenshots"));
 
         column_end.attach (screenshots_header, 0, 10, 2);
-        column_end.attach (new NameLabel (_("Grab the whole screen:")), 0, 11);
-        column_end.attach (new ShortcutLabel.from_gsettings (SCHEMA_GALA, "screenshot"), 1, 11);
-        column_end.attach (new NameLabel (_("Copy the whole screen to clipboard:")), 0, 12);
-        column_end.attach (new ShortcutLabel.from_gsettings (SCHEMA_GALA, "screenshot-clip"), 1, 12);
-        column_end.attach (new NameLabel (_("Grab the current window:")), 0, 13);
-        column_end.attach (new ShortcutLabel.from_gsettings (SCHEMA_GALA, "window-screenshot"), 1, 13);
-        column_end.attach (new NameLabel (_("Copy the current window to clipboard:")), 0, 14);
-        column_end.attach (new ShortcutLabel.from_gsettings (SCHEMA_GALA, "window-screenshot-clip"), 1, 14);
-        column_end.attach (new NameLabel (_("Select an area to grab:")), 0, 15);
-        column_end.attach (new ShortcutLabel.from_gsettings (SCHEMA_GALA, "area-screenshot"), 1, 15);
-        column_end.attach (new NameLabel (_("Copy an area to clipboard:")), 0, 16);
-        column_end.attach (new ShortcutLabel.from_gsettings (SCHEMA_GALA, "area-screenshot-clip"), 1, 16);
-
-        var column_size_group = new Gtk.SizeGroup (Gtk.SizeGroupMode.HORIZONTAL);
-        column_size_group.add_widget (column_start);
-        column_size_group.add_widget (column_end);
+        column_end.attach (new ShortcutLabel.from_gsettings (_("Grab the whole screen:"), SCHEMA_GALA, "screenshot"), 0, 11);
+        column_end.attach (new ShortcutLabel.from_gsettings (_("Copy the whole screen to clipboard:"), SCHEMA_GALA, "screenshot-clip"), 0, 12);
+        column_end.attach (new ShortcutLabel.from_gsettings (_("Grab the current window:"), SCHEMA_GALA, "window-screenshot"), 0, 13);
+        column_end.attach (new ShortcutLabel.from_gsettings (_("Copy the current window to clipboard:"), SCHEMA_GALA, "window-screenshot-clip"), 0, 14);
+        column_end.attach (new ShortcutLabel.from_gsettings (_("Select an area to grab:"), SCHEMA_GALA, "area-screenshot"), 0, 15);
+        column_end.attach (new ShortcutLabel.from_gsettings (_("Copy an area to clipboard:"), SCHEMA_GALA, "area-screenshot-clip"), 0, 16);
 
         spacing = 48;
         append (column_start);
         append (new Gtk.Separator (Gtk.Orientation.VERTICAL));
         append (column_end);
-    }
-
-    private class NameLabel : Gtk.Box {
-        public string label { get; construct; }
-
-        public NameLabel (string label) {
-            Object (label: label);
-        }
-
-        construct {
-            var label = new Gtk.Label (label);
-
-            halign = Gtk.Align.END;
-            append (label);
-        }
     }
 }


### PR DESCRIPTION
Part of #151 

Adds the human-readable label to the ShortcutLabel widget so that each shortcut is a single widget. This will make it a lot easier later to pack them into a listbox so they can be navigated by keyboard and read by the screen reader